### PR TITLE
fix: re-add role policy co-provisioning

### DIFF
--- a/humanitec-resource-defs/iam-role/service-account/README.md
+++ b/humanitec-resource-defs/iam-role/service-account/README.md
@@ -28,6 +28,7 @@
 | region | n/a | `string` | n/a | yes |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
+| policy\_classes | Humanitec aws-policy classes to provision by default for this role. | `list(string)` | `[]` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 
 ## Outputs

--- a/humanitec-resource-defs/iam-role/service-account/main.tf
+++ b/humanitec-resource-defs/iam-role/service-account/main.tf
@@ -4,6 +4,13 @@ resource "humanitec_resource_definition" "main" {
   name        = "${var.prefix}aws-workload-role"
   type        = "aws-role"
 
+  provision = {
+    for s in var.policy_classes : "aws-policy.${s}" => {
+      match_dependents = true
+      is_dependent     = false
+    }
+  }
+
   driver_inputs = {
     secrets_string = jsonencode({
       variables = {

--- a/humanitec-resource-defs/iam-role/service-account/terraform.tfvars.example
+++ b/humanitec-resource-defs/iam-role/service-account/terraform.tfvars.example
@@ -1,7 +1,11 @@
 access_key   = ""
 cluster_name = ""
-prefix       = ""
-region       = ""
+
+# Humanitec aws-policy classes to provision by default for this role.
+policy_classes = []
+
+prefix = ""
+region = ""
 
 # AWS Resource Pack git branch
 resource_packs_aws_rev = ""

--- a/humanitec-resource-defs/iam-role/service-account/variables.tf
+++ b/humanitec-resource-defs/iam-role/service-account/variables.tf
@@ -28,3 +28,9 @@ variable "region" {
 variable "cluster_name" {
   type = string
 }
+
+variable "policy_classes" {
+  description = "Humanitec aws-policy classes to provision by default for this role."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
This is used inside the backstage ref-arch to [attach the ECR push policy to the workload](https://github.com/humanitec-architecture/reference-architecture-aws/blob/main/examples/with-backstage/backstage-humanitec.tf#L154) and was accidentally removed in https://github.com/humanitec-architecture/resource-packs-aws/pull/10.

