### PR TITLE
fix: role without policies

### DIFF
--- a/humanitec-resource-defs/iam-role/service-account/main.tf
+++ b/humanitec-resource-defs/iam-role/service-account/main.tf
@@ -1,15 +1,19 @@
+locals {
+  co_provisioned = {
+    for s in var.policy_classes : "aws-policy.${s}" => {
+      match_dependents = true
+      is_dependent     = false
+    }
+  }
+}
+
 resource "humanitec_resource_definition" "main" {
   driver_type = "humanitec/terraform"
   id          = "${var.prefix}aws-workload-role"
   name        = "${var.prefix}aws-workload-role"
   type        = "aws-role"
 
-  provision = {
-    for s in var.policy_classes : "aws-policy.${s}" => {
-      match_dependents = true
-      is_dependent     = false
-    }
-  }
+  provision = length(var.policy_classes) > 0 ? local.co_provisioned : null
 
   driver_inputs = {
     secrets_string = jsonencode({


### PR DESCRIPTION
Otherwise the apply fails with 

```
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to module.iam_role_service_account.humanitec_resource_definition.main, provider
│ "provider[\"registry.terraform.io/humanitec/humanitec\"]" produced an unexpected new value: .provision: was
│ cty.MapValEmpty(cty.Object(map[string]cty.Type{"is_dependent":cty.Bool, "match_dependents":cty.Bool})), but now null.
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
```