### PR TITLE
chore: align resource naming

### DIFF
--- a/examples/dns/README.md
+++ b/examples/dns/README.md
@@ -44,9 +44,10 @@ resources:
 |------|-------------|------|---------|:--------:|
 | access\_key | AWS Access Key | `string` | n/a | yes |
 | hosted\_zone\_id | The id of the hosted zone in which this record set will reside. | `string` | n/a | yes |
-| name | Name of the example application | `string` | n/a | yes |
 | region | AWS Region | `string` | n/a | yes |
 | secret\_key | AWS Secret Key | `string` | n/a | yes |
+| name | Name of the example application | `string` | `"hum-rp-dns-example"` | no |
+| prefix | Prefix of the created resources | `string` | `"hum-rp-dns-ex-"` | no |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 <!-- END_TF_DOCS -->

--- a/examples/dns/main.tf
+++ b/examples/dns/main.tf
@@ -1,7 +1,3 @@
-locals {
-  res_def_prefix = "${var.name}-"
-}
-
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -16,7 +12,7 @@ module "route53" {
   resource_packs_aws_rev = var.resource_packs_aws_rev
   region                 = var.region
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 
   hosted_zone_id = var.hosted_zone_id
 }

--- a/examples/dns/terraform.tfvars.example
+++ b/examples/dns/terraform.tfvars.example
@@ -6,7 +6,10 @@ access_key = ""
 hosted_zone_id = ""
 
 # Name of the example application
-name = ""
+name = "hum-rp-dns-example"
+
+# Prefix of the created resources
+prefix = "hum-rp-dns-ex-"
 
 # AWS Region
 region = ""

--- a/examples/dns/variables.tf
+++ b/examples/dns/variables.tf
@@ -25,12 +25,19 @@ variable "resource_packs_aws_rev" {
   default     = "refs/heads/main"
 }
 
-variable "name" {
-  description = "Name of the example application"
-  type        = string
-}
-
 variable "hosted_zone_id" {
   description = "The id of the hosted zone in which this record set will reside."
   type        = string
+}
+
+variable "name" {
+  description = "Name of the example application"
+  type        = string
+  default     = "hum-rp-dns-example"
+}
+
+variable "prefix" {
+  description = "Prefix of the created resources"
+  type        = string
+  default     = "hum-rp-dns-ex-"
 }

--- a/examples/mysql/aurora/README.md
+++ b/examples/mysql/aurora/README.md
@@ -47,12 +47,13 @@ resources:
 | humanitec\_org\_id | Humanitec organization where resource definitions will be applied | `string` | n/a | yes |
 | humanitec\_token | Humanitec API token | `string` | n/a | yes |
 | k8s\_node\_security\_group\_id | AWS Security Group ID of the kubernetes nodes to allow access to the AWS RDS cluster | `string` | n/a | yes |
-| name | Name that will be used in resouces' names | `string` | n/a | yes |
 | region | AWS Region to create resources | `string` | n/a | yes |
 | secret\_key | AWS Secret Key | `string` | n/a | yes |
 | subnet\_ids | AWS Subnet IDs to use for the AWS RDS cluster | `set(string)` | n/a | yes |
 | vpc\_id | AWS VPC ID | `string` | n/a | yes |
 | humanitec\_host | Humanitec API host url | `string` | `"https://api.humanitec.io"` | no |
+| name | Name of the example application | `string` | `"hum-rp-mysql-example"` | no |
+| prefix | Prefix of the created resources | `string` | `"hum-rp-mysql-ex-"` | no |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 <!-- END_TF_DOCS -->

--- a/examples/mysql/aurora/main.tf
+++ b/examples/mysql/aurora/main.tf
@@ -6,7 +6,6 @@ resource "humanitec_application" "app" {
 module "mysql" {
   source = "../../../humanitec-resource-defs/mysql/aurora"
 
-  prefix                 = "${var.name}-"
   resource_packs_aws_rev = var.resource_packs_aws_rev
   resource_packs_aws_url = var.resource_packs_aws_url
 
@@ -14,14 +13,14 @@ module "mysql" {
   secret_key = var.secret_key
   region     = var.region
 
-  name            = "${var.name}-database"
+  prefix          = var.prefix
+  name            = var.name
   database_name   = "my_database"
   master_username = "username"
   master_password = "password"
 
   vpc                    = var.vpc_id
   subnets                = var.subnet_ids
-  db_subnet_group_name   = "${var.name}-subnet-group"
   create_db_subnet_group = true
   security_group_rules = {
     ingress = {

--- a/examples/mysql/aurora/terraform.tfvars.example
+++ b/examples/mysql/aurora/terraform.tfvars.example
@@ -14,8 +14,11 @@ humanitec_token = ""
 # AWS Security Group ID of the kubernetes nodes to allow access to the AWS RDS cluster
 k8s_node_security_group_id = ""
 
-# Name that will be used in resouces' names
-name = ""
+# Name of the example application
+name = "hum-rp-mysql-example"
+
+# Prefix of the created resources
+prefix = "hum-rp-mysql-ex-"
 
 # AWS Region to create resources
 region = ""

--- a/examples/mysql/aurora/variables.tf
+++ b/examples/mysql/aurora/variables.tf
@@ -1,8 +1,3 @@
-variable "name" {
-  type        = string
-  description = "Name that will be used in resouces' names"
-}
-
 variable "access_key" {
   type        = string
   description = "AWS Access Key"
@@ -59,4 +54,16 @@ variable "subnet_ids" {
 variable "k8s_node_security_group_id" {
   description = "AWS Security Group ID of the kubernetes nodes to allow access to the AWS RDS cluster"
   type        = string
+}
+
+variable "name" {
+  description = "Name of the example application"
+  type        = string
+  default     = "hum-rp-mysql-example"
+}
+
+variable "prefix" {
+  description = "Prefix of the created resources"
+  type        = string
+  default     = "hum-rp-mysql-ex-"
 }

--- a/examples/mysql/basic/README.md
+++ b/examples/mysql/basic/README.md
@@ -50,12 +50,13 @@ resources:
 | humanitec\_org\_id | Humanitec organization where resource definitions will be applied | `string` | n/a | yes |
 | humanitec\_token | Humanitec API token | `string` | n/a | yes |
 | k8s\_node\_security\_group\_id | AWS Security Group ID of the kubernetes nodes to allow access to the AWS RDS cluster | `string` | n/a | yes |
-| name | Name that will be used in resouces' names | `string` | n/a | yes |
 | region | AWS Region to create resources | `string` | n/a | yes |
 | secret\_key | AWS Secret Key | `string` | n/a | yes |
 | subnet\_ids | AWS Subnet IDs to use for the AWS RDS cluster | `set(string)` | n/a | yes |
 | vpc\_id | AWS VPC ID | `string` | n/a | yes |
 | humanitec\_host | Humanitec API host url | `string` | `"https://api.humanitec.io"` | no |
+| name | Name of the example application | `string` | `"hum-rp-mysql-example"` | no |
+| prefix | Prefix of the created resources | `string` | `"hum-rp-mysql-ex-"` | no |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 <!-- END_TF_DOCS -->

--- a/examples/mysql/basic/main.tf
+++ b/examples/mysql/basic/main.tf
@@ -6,7 +6,6 @@ resource "humanitec_application" "app" {
 module "mysql" {
   source = "../../../humanitec-resource-defs/mysql/basic"
 
-  prefix                 = "${var.name}-"
   resource_packs_aws_rev = var.resource_packs_aws_rev
   resource_packs_aws_url = var.resource_packs_aws_url
 
@@ -14,13 +13,13 @@ module "mysql" {
   secret_key = var.secret_key
   region     = var.region
 
-  name          = "${var.name}-database"
+  prefix        = var.prefix
+  name          = var.name
   database_name = "my_database"
   username      = "username"
   password      = "password"
 
   create_db_subnet_group = true
-  db_subnet_group_name   = "${var.name}-subnet-group"
   subnet_ids             = var.subnet_ids
 
   vpc_security_group_ids = [aws_security_group.mysql.id]

--- a/examples/mysql/basic/terraform.tfvars.example
+++ b/examples/mysql/basic/terraform.tfvars.example
@@ -14,8 +14,11 @@ humanitec_token = ""
 # AWS Security Group ID of the kubernetes nodes to allow access to the AWS RDS cluster
 k8s_node_security_group_id = ""
 
-# Name that will be used in resouces' names
-name = ""
+# Name of the example application
+name = "hum-rp-mysql-example"
+
+# Prefix of the created resources
+prefix = "hum-rp-mysql-ex-"
 
 # AWS Region to create resources
 region = ""

--- a/examples/mysql/basic/variables.tf
+++ b/examples/mysql/basic/variables.tf
@@ -1,8 +1,3 @@
-variable "name" {
-  type        = string
-  description = "Name that will be used in resouces' names"
-}
-
 variable "access_key" {
   type        = string
   description = "AWS Access Key"
@@ -59,4 +54,16 @@ variable "subnet_ids" {
 variable "k8s_node_security_group_id" {
   description = "AWS Security Group ID of the kubernetes nodes to allow access to the AWS RDS cluster"
   type        = string
+}
+
+variable "name" {
+  description = "Name of the example application"
+  type        = string
+  default     = "hum-rp-mysql-example"
+}
+
+variable "prefix" {
+  description = "Prefix of the created resources"
+  type        = string
+  default     = "hum-rp-mysql-ex-"
 }

--- a/examples/postgres/aurora/README.md
+++ b/examples/postgres/aurora/README.md
@@ -47,12 +47,13 @@ resources:
 | humanitec\_org\_id | Humanitec organization where resource definitions will be applied | `string` | n/a | yes |
 | humanitec\_token | Humanitec API token | `string` | n/a | yes |
 | k8s\_node\_security\_group\_id | AWS Security Group ID of the kubernetes nodes to allow access to the AWS RDS cluster | `string` | n/a | yes |
-| name | Name that will be used in resouces' names | `string` | n/a | yes |
 | region | AWS Region to create resources | `string` | n/a | yes |
 | secret\_key | AWS Secret Key | `string` | n/a | yes |
 | subnet\_ids | AWS Subnet IDs to use for the AWS RDS cluster | `set(string)` | n/a | yes |
 | vpc\_id | AWS VPC ID | `string` | n/a | yes |
 | humanitec\_host | Humanitec API host url | `string` | `"https://api.humanitec.io"` | no |
+| name | Name of the example application | `string` | `"hum-rp-postgres-example"` | no |
+| prefix | Prefix of the created resources | `string` | `"hum-rp-postgres-ex-"` | no |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 <!-- END_TF_DOCS -->

--- a/examples/postgres/aurora/main.tf
+++ b/examples/postgres/aurora/main.tf
@@ -6,7 +6,6 @@ resource "humanitec_application" "app" {
 module "postgres" {
   source = "../../../humanitec-resource-defs/postgres/aurora"
 
-  prefix                 = "${var.name}-"
   resource_packs_aws_rev = var.resource_packs_aws_rev
   resource_packs_aws_url = var.resource_packs_aws_url
 
@@ -14,14 +13,14 @@ module "postgres" {
   secret_key = var.secret_key
   region     = var.region
 
-  name            = "${var.name}-database"
+  prefix          = var.prefix
+  name            = var.name
   database_name   = "my_database"
   master_username = "username"
   master_password = "password"
 
   vpc                    = var.vpc_id
   subnets                = var.subnet_ids
-  db_subnet_group_name   = "${var.name}-subnet-group"
   create_db_subnet_group = true
   security_group_rules = {
     ingress = {

--- a/examples/postgres/aurora/terraform.tfvars.example
+++ b/examples/postgres/aurora/terraform.tfvars.example
@@ -14,8 +14,11 @@ humanitec_token = ""
 # AWS Security Group ID of the kubernetes nodes to allow access to the AWS RDS cluster
 k8s_node_security_group_id = ""
 
-# Name that will be used in resouces' names
-name = ""
+# Name of the example application
+name = "hum-rp-postgres-example"
+
+# Prefix of the created resources
+prefix = "hum-rp-postgres-ex-"
 
 # AWS Region to create resources
 region = ""

--- a/examples/postgres/aurora/variables.tf
+++ b/examples/postgres/aurora/variables.tf
@@ -1,8 +1,3 @@
-variable "name" {
-  type        = string
-  description = "Name that will be used in resouces' names"
-}
-
 variable "access_key" {
   type        = string
   description = "AWS Access Key"
@@ -59,4 +54,16 @@ variable "subnet_ids" {
 variable "k8s_node_security_group_id" {
   description = "AWS Security Group ID of the kubernetes nodes to allow access to the AWS RDS cluster"
   type        = string
+}
+
+variable "name" {
+  description = "Name of the example application"
+  type        = string
+  default     = "hum-rp-postgres-example"
+}
+
+variable "prefix" {
+  description = "Prefix of the created resources"
+  type        = string
+  default     = "hum-rp-postgres-ex-"
 }

--- a/examples/postgres/basic/README.md
+++ b/examples/postgres/basic/README.md
@@ -50,12 +50,13 @@ resources:
 | humanitec\_org\_id | Humanitec organization where resource definitions will be applied | `string` | n/a | yes |
 | humanitec\_token | Humanitec API token | `string` | n/a | yes |
 | k8s\_node\_security\_group\_id | AWS Security Group ID of the kubernetes nodes to allow access to the AWS RDS cluster | `string` | n/a | yes |
-| name | Name that will be used in resouces' names | `string` | n/a | yes |
 | region | AWS Region to create resources | `string` | n/a | yes |
 | secret\_key | AWS Secret Key | `string` | n/a | yes |
 | subnet\_ids | AWS Subnet IDs to use for the AWS RDS cluster | `set(string)` | n/a | yes |
 | vpc\_id | AWS VPC ID | `string` | n/a | yes |
 | humanitec\_host | Humanitec API host url | `string` | `"https://api.humanitec.io"` | no |
+| name | Name of the example application | `string` | `"hum-rp-postgres-example"` | no |
+| prefix | Prefix of the created resources | `string` | `"hum-rp-postgres-ex-"` | no |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 <!-- END_TF_DOCS -->

--- a/examples/postgres/basic/main.tf
+++ b/examples/postgres/basic/main.tf
@@ -6,7 +6,6 @@ resource "humanitec_application" "app" {
 module "postgres" {
   source = "../../../humanitec-resource-defs/postgres/basic"
 
-  prefix                 = "${var.name}-"
   resource_packs_aws_rev = var.resource_packs_aws_rev
   resource_packs_aws_url = var.resource_packs_aws_url
 
@@ -14,13 +13,13 @@ module "postgres" {
   secret_key = var.secret_key
   region     = var.region
 
-  name          = "${var.name}-database"
+  prefix        = var.prefix
+  name          = var.name
   database_name = "my_database"
   username      = "username"
   password      = "password"
 
   create_db_subnet_group = true
-  db_subnet_group_name   = "${var.name}-subnet-group"
   subnet_ids             = var.subnet_ids
 
   vpc_security_group_ids = [aws_security_group.postgres.id]

--- a/examples/postgres/basic/terraform.tfvars.example
+++ b/examples/postgres/basic/terraform.tfvars.example
@@ -14,8 +14,11 @@ humanitec_token = ""
 # AWS Security Group ID of the kubernetes nodes to allow access to the AWS RDS cluster
 k8s_node_security_group_id = ""
 
-# Name that will be used in resouces' names
-name = ""
+# Name of the example application
+name = "hum-rp-postgres-example"
+
+# Prefix of the created resources
+prefix = "hum-rp-postgres-ex-"
 
 # AWS Region to create resources
 region = ""

--- a/examples/postgres/basic/variables.tf
+++ b/examples/postgres/basic/variables.tf
@@ -1,8 +1,3 @@
-variable "name" {
-  type        = string
-  description = "Name that will be used in resouces' names"
-}
-
 variable "access_key" {
   type        = string
   description = "AWS Access Key"
@@ -59,4 +54,16 @@ variable "subnet_ids" {
 variable "k8s_node_security_group_id" {
   description = "AWS Security Group ID of the kubernetes nodes to allow access to the AWS RDS cluster"
   type        = string
+}
+
+variable "name" {
+  description = "Name of the example application"
+  type        = string
+  default     = "hum-rp-postgres-example"
+}
+
+variable "prefix" {
+  description = "Prefix of the created resources"
+  type        = string
+  default     = "hum-rp-postgres-ex-"
 }

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -53,7 +53,8 @@ resources:
 | secret\_key | AWS Secret Key | `string` | n/a | yes |
 | subnet\_ids | AWS Subnet IDs to use for the AWS ElastiCache cluster | `set(string)` | n/a | yes |
 | vpc\_id | AWS VPC ID | `string` | n/a | yes |
-| name | Name of the example application | `string` | `"redis-test"` | no |
+| name | Name of the example application | `string` | `"hum-rp-redis-example"` | no |
+| prefix | Prefix of the created resources | `string` | `"hum-rp-redis-ex-"` | no |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 <!-- END_TF_DOCS -->

--- a/examples/redis/main.tf
+++ b/examples/redis/main.tf
@@ -1,7 +1,3 @@
-locals {
-  res_def_prefix = "${var.name}-"
-}
-
 # Prepare application, subnet group and security group
 
 resource "humanitec_application" "example" {
@@ -40,7 +36,7 @@ module "redis" {
   resource_packs_aws_rev = var.resource_packs_aws_rev
   region                 = var.region
 
-  prefix             = local.res_def_prefix
+  prefix             = var.prefix
   subnet_group_name  = aws_elasticache_subnet_group.redis.name
   security_group_ids = [aws_security_group.redis.id]
 }

--- a/examples/redis/terraform.tfvars.example
+++ b/examples/redis/terraform.tfvars.example
@@ -6,7 +6,10 @@ access_key = ""
 k8s_node_security_group_id = ""
 
 # Name of the example application
-name = "redis-test"
+name = "hum-rp-redis-example"
+
+# Prefix of the created resources
+prefix = "hum-rp-redis-ex-"
 
 # AWS Region
 region = ""

--- a/examples/redis/variables.tf
+++ b/examples/redis/variables.tf
@@ -43,5 +43,11 @@ variable "resource_packs_aws_rev" {
 variable "name" {
   description = "Name of the example application"
   type        = string
-  default     = "redis-test"
+  default     = "hum-rp-redis-example"
+}
+
+variable "prefix" {
+  description = "Prefix of the created resources"
+  type        = string
+  default     = "hum-rp-redis-ex-"
 }

--- a/examples/s3/README.md
+++ b/examples/s3/README.md
@@ -66,7 +66,8 @@ The workload service account will automatically be assigned the necessary AWS IA
 | cluster\_name | Name of the EKS cluster | `string` | n/a | yes |
 | region | AWS Region | `string` | n/a | yes |
 | secret\_key | AWS Secret Key | `string` | n/a | yes |
-| name | Name of the example application | `string` | `"s3-test"` | no |
+| name | Name of the example application | `string` | `"hum-rp-s3-example"` | no |
+| prefix | Prefix of the created resources | `string` | `"hum-rp-s3-ex-"` | no |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 <!-- END_TF_DOCS -->

--- a/examples/s3/main.tf
+++ b/examples/s3/main.tf
@@ -1,7 +1,3 @@
-locals {
-  res_def_prefix = "${var.name}-"
-}
-
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -32,7 +28,7 @@ module "s3_basic" {
   secret_key = var.secret_key
   region     = var.region
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 }
 
 resource "humanitec_resource_definition_criteria" "s3_basic" {
@@ -58,7 +54,7 @@ module "iam_policy_s3_admin" {
 
   policy = "admin"
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 
   s3_resource_class = local.s3_basic_class
 }
@@ -73,7 +69,7 @@ resource "humanitec_resource_definition_criteria" "iam_policy_s3_admin" {
 module "s3_basic_admin" {
   source = "../../humanitec-resource-defs/s3/passthrough"
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 
   s3_resource_class     = local.s3_basic_class
   policy_resource_class = local.s3_admin_policy_class
@@ -101,7 +97,7 @@ module "iam_policy_s3_read_only" {
 
   policy = "read-only"
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 
   s3_resource_class = local.s3_basic_class
 }
@@ -116,7 +112,7 @@ resource "humanitec_resource_definition_criteria" "iam_policy_s3_read_only" {
 module "s3_basic_read_only" {
   source = "../../humanitec-resource-defs/s3/passthrough"
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 
   s3_resource_class     = local.s3_basic_class
   policy_resource_class = local.s3_read_only_policy_class
@@ -134,7 +130,7 @@ resource "humanitec_resource_definition_criteria" "s3_basic_read_only" {
 module "k8s_service_account" {
   source = "../../humanitec-resource-defs/k8s/service-account"
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 }
 
 resource "humanitec_resource_definition_criteria" "k8s_service_account" {
@@ -153,7 +149,7 @@ module "iam_role_service_account" {
   region     = var.region
 
   cluster_name = var.cluster_name
-  prefix       = local.res_def_prefix
+  prefix       = var.prefix
 }
 
 resource "humanitec_resource_definition_criteria" "iam_role_service_account" {
@@ -164,7 +160,7 @@ resource "humanitec_resource_definition_criteria" "iam_role_service_account" {
 module "workload" {
   source = "../../humanitec-resource-defs/workload/service-account"
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 }
 
 resource "humanitec_resource_definition_criteria" "workload" {

--- a/examples/s3/terraform.tfvars.example
+++ b/examples/s3/terraform.tfvars.example
@@ -6,7 +6,10 @@ access_key = ""
 cluster_name = ""
 
 # Name of the example application
-name = "s3-test"
+name = "hum-rp-s3-example"
+
+# Prefix of the created resources
+prefix = "hum-rp-s3-ex-"
 
 # AWS Region
 region = ""

--- a/examples/s3/variables.tf
+++ b/examples/s3/variables.tf
@@ -33,5 +33,11 @@ variable "resource_packs_aws_rev" {
 variable "name" {
   description = "Name of the example application"
   type        = string
-  default     = "s3-test"
+  default     = "hum-rp-s3-example"
+}
+
+variable "prefix" {
+  description = "Prefix of the created resources"
+  type        = string
+  default     = "hum-rp-s3-ex-"
 }

--- a/examples/sqs/README.md
+++ b/examples/sqs/README.md
@@ -66,7 +66,8 @@ The workload service account will automatically be assigned the necessary AWS IA
 | cluster\_name | Name of the EKS cluster | `string` | n/a | yes |
 | region | AWS Region | `string` | n/a | yes |
 | secret\_key | AWS Secret Key | `string` | n/a | yes |
-| name | Name of the example application | `string` | `"sqs-test"` | no |
+| name | Name of the example application | `string` | `"hum-rp-s3-example"` | no |
+| prefix | Prefix of the created resources | `string` | `"hum-rp-s3-ex-"` | no |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | `"refs/heads/main"` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 <!-- END_TF_DOCS -->

--- a/examples/sqs/main.tf
+++ b/examples/sqs/main.tf
@@ -1,7 +1,3 @@
-locals {
-  res_def_prefix = "${var.name}-"
-}
-
 resource "humanitec_application" "example" {
   id   = var.name
   name = var.name
@@ -32,7 +28,7 @@ module "sqs_basic" {
   secret_key = var.secret_key
   region     = var.region
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 }
 
 resource "humanitec_resource_definition_criteria" "sqs_basic" {
@@ -57,7 +53,7 @@ module "iam_policy_sqs_publisher" {
   secret_key = var.secret_key
   region     = var.region
 
-  prefix             = local.res_def_prefix
+  prefix             = var.prefix
   policy             = "publisher"
   sqs_resource_class = local.sqs_basic_publisher_class
 }
@@ -72,7 +68,7 @@ resource "humanitec_resource_definition_criteria" "iam_policy_sqs_publisher" {
 module "sqs_basic_publisher" {
   source = "../../humanitec-resource-defs/sqs/passthrough"
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 
   sqs_resource_class    = local.sqs_basic_class
   policy_resource_class = local.sqs_publisher_policy_class
@@ -99,7 +95,7 @@ module "iam_policy_sqs_consumer" {
 
   policy = "consumer"
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 
   sqs_resource_class = local.sqs_basic_consumer_class
 }
@@ -114,7 +110,7 @@ resource "humanitec_resource_definition_criteria" "iam_policy_sqs_consumer" {
 module "sqs_basic_consumer" {
   source = "../../humanitec-resource-defs/sqs/passthrough"
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 
   sqs_resource_class    = local.sqs_basic_class
   policy_resource_class = local.sqs_consumer_policy_class
@@ -132,7 +128,7 @@ resource "humanitec_resource_definition_criteria" "sqs_basic_consumer" {
 module "k8s_service_account" {
   source = "../../humanitec-resource-defs/k8s/service-account"
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 }
 
 resource "humanitec_resource_definition_criteria" "k8s_service_account" {
@@ -151,7 +147,7 @@ module "iam_role_service_account" {
   region     = var.region
 
   cluster_name = var.cluster_name
-  prefix       = local.res_def_prefix
+  prefix       = var.prefix
 }
 
 resource "humanitec_resource_definition_criteria" "iam_role_service_account" {
@@ -162,7 +158,7 @@ resource "humanitec_resource_definition_criteria" "iam_role_service_account" {
 module "workload" {
   source = "../../humanitec-resource-defs/workload/service-account"
 
-  prefix = local.res_def_prefix
+  prefix = var.prefix
 }
 
 resource "humanitec_resource_definition_criteria" "workload" {

--- a/examples/sqs/terraform.tfvars.example
+++ b/examples/sqs/terraform.tfvars.example
@@ -6,7 +6,10 @@ access_key = ""
 cluster_name = ""
 
 # Name of the example application
-name = "sqs-test"
+name = "hum-rp-s3-example"
+
+# Prefix of the created resources
+prefix = "hum-rp-s3-ex-"
 
 # AWS Region
 region = ""

--- a/examples/sqs/variables.tf
+++ b/examples/sqs/variables.tf
@@ -33,5 +33,11 @@ variable "resource_packs_aws_rev" {
 variable "name" {
   description = "Name of the example application"
   type        = string
-  default     = "sqs-test"
+  default     = "hum-rp-s3-example"
+}
+
+variable "prefix" {
+  description = "Prefix of the created resources"
+  type        = string
+  default     = "hum-rp-s3-ex-"
 }

--- a/humanitec-resource-defs/iam-role/service-account/README.md
+++ b/humanitec-resource-defs/iam-role/service-account/README.md
@@ -24,10 +24,11 @@
 |------|-------------|------|---------|:--------:|
 | access\_key | n/a | `string` | n/a | yes |
 | cluster\_name | n/a | `string` | n/a | yes |
-| prefix | n/a | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
 | region | n/a | `string` | n/a | yes |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
+| name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | policy\_classes | Humanitec aws-policy classes to provision by default for this role. | `list(string)` | `[]` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 

--- a/humanitec-resource-defs/iam-role/service-account/main.tf
+++ b/humanitec-resource-defs/iam-role/service-account/main.tf
@@ -31,8 +31,10 @@ resource "humanitec_resource_definition" "main" {
       }
 
       variables = {
-        region       = var.region,
-        prefix       = "${var.prefix}$${context.res.id}"
+        region = var.region
+        prefix = var.prefix
+        name   = var.name
+
         policy_arns  = "$${resources.workload>aws-policy.outputs.arn}"
         cluster_name = var.cluster_name
         namespace    = "$${resources.k8s-namespace#k8s-namespace.outputs.namespace}"

--- a/humanitec-resource-defs/iam-role/service-account/terraform.tfvars.example
+++ b/humanitec-resource-defs/iam-role/service-account/terraform.tfvars.example
@@ -1,10 +1,15 @@
 access_key   = ""
 cluster_name = ""
 
+# Resource name (can contain placeholders like ${context.app.id})
+name = ""
+
 # Humanitec aws-policy classes to provision by default for this role.
 policy_classes = []
 
+# Prefix for all resources
 prefix = ""
+
 region = ""
 
 # AWS Resource Pack git branch

--- a/humanitec-resource-defs/iam-role/service-account/variables.tf
+++ b/humanitec-resource-defs/iam-role/service-account/variables.tf
@@ -1,5 +1,6 @@
 variable "prefix" {
-  type = string
+  description = "Prefix for all resources"
+  type        = string
 }
 
 variable "resource_packs_aws_url" {
@@ -33,4 +34,10 @@ variable "policy_classes" {
   description = "Humanitec aws-policy classes to provision by default for this role."
   type        = list(string)
   default     = []
+}
+
+variable "name" {
+  type        = string
+  description = "Resource name (can contain placeholders like $${context.app.id})"
+  default     = ""
 }

--- a/humanitec-resource-defs/mysql/aurora/README.md
+++ b/humanitec-resource-defs/mysql/aurora/README.md
@@ -24,11 +24,9 @@
 |------|-------------|------|---------|:--------:|
 | access\_key | n/a | `string` | n/a | yes |
 | database\_name | n/a | `string` | n/a | yes |
-| db\_subnet\_group\_name | n/a | `string` | n/a | yes |
 | master\_password | n/a | `string` | n/a | yes |
 | master\_username | n/a | `string` | n/a | yes |
-| name | n/a | `string` | n/a | yes |
-| prefix | n/a | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
 | region | n/a | `string` | n/a | yes |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
@@ -42,12 +40,14 @@
 | db\_cluster\_activity\_stream\_mode | n/a | `string` | `"async"` | no |
 | db\_cluster\_parameter\_group\_parameters | n/a | `set(any)` | `[]` | no |
 | db\_parameter\_group\_parameters | n/a | `set(any)` | `[]` | no |
+| db\_subnet\_group\_name | DB subnet group name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | enabled\_cloudwatch\_logs\_exports | n/a | `set(string)` | `[]` | no |
 | endpoints | n/a | `any` | `{}` | no |
 | engine | n/a | `string` | `"aurora-mysql"` | no |
 | engine\_version | n/a | `string` | `"8.0"` | no |
 | group\_family | n/a | `string` | `"aurora-mysql8.0"` | no |
 | instances | n/a | `map(any)` | <pre>{<br>  "1": {<br>    "db_parameter_group_name": "default.aurora-mysql8.0",<br>    "instance_class": "db.r5.2xlarge",<br>    "publicly_accessible": true<br>  },<br>  "2": {<br>    "identifier": "static-member-1",<br>    "instance_class": "db.r5.2xlarge"<br>  }<br>}</pre> | no |
+| name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 | security\_group\_rules | n/a | `any` | `{}` | no |
 | skip\_final\_snapshot | n/a | `bool` | `true` | no |

--- a/humanitec-resource-defs/mysql/aurora/main.tf
+++ b/humanitec-resource-defs/mysql/aurora/main.tf
@@ -25,6 +25,7 @@ resource "humanitec_resource_definition" "main" {
         app_id = "$${context.app.id}"
         env_id = "$${context.env.id}"
 
+        prefix                                = var.prefix
         name                                  = var.name
         database_name                         = var.database_name
         master_username                       = var.master_username

--- a/humanitec-resource-defs/mysql/aurora/terraform.tfvars.example
+++ b/humanitec-resource-defs/mysql/aurora/terraform.tfvars.example
@@ -8,12 +8,15 @@ db_cluster_activity_stream_kms_key_id = ""
 db_cluster_activity_stream_mode       = "async"
 db_cluster_parameter_group_parameters = []
 db_parameter_group_parameters         = []
-db_subnet_group_name                  = ""
-enabled_cloudwatch_logs_exports       = []
-endpoints                             = {}
-engine                                = "aurora-mysql"
-engine_version                        = "8.0"
-group_family                          = "aurora-mysql8.0"
+
+# DB subnet group name (can contain placeholders like ${context.app.id})
+db_subnet_group_name = ""
+
+enabled_cloudwatch_logs_exports = []
+endpoints                       = {}
+engine                          = "aurora-mysql"
+engine_version                  = "8.0"
+group_family                    = "aurora-mysql8.0"
 instances = {
   "1": {
     "db_parameter_group_name": "default.aurora-mysql8.0",
@@ -27,9 +30,14 @@ instances = {
 }
 master_password = ""
 master_username = ""
-name            = ""
-prefix          = ""
-region          = ""
+
+# Resource name (can contain placeholders like ${context.app.id})
+name = ""
+
+# Prefix for all resources
+prefix = ""
+
+region = ""
 
 # AWS Resource Pack git branch
 resource_packs_aws_rev = ""

--- a/humanitec-resource-defs/mysql/aurora/variables.tf
+++ b/humanitec-resource-defs/mysql/aurora/variables.tf
@@ -1,5 +1,6 @@
 variable "prefix" {
-  type = string
+  description = "Prefix for all resources"
+  type        = string
 }
 
 variable "resource_packs_aws_url" {
@@ -26,7 +27,9 @@ variable "region" {
 }
 
 variable "name" {
-  type = string
+  type        = string
+  description = "Resource name (can contain placeholders like $${context.app.id})"
+  default     = ""
 }
 
 variable "database_name" {
@@ -50,7 +53,9 @@ variable "subnets" {
 }
 
 variable "db_subnet_group_name" {
-  type = string
+  type        = string
+  description = "DB subnet group name (can contain placeholders like $${context.app.id})"
+  default     = ""
 }
 
 variable "create_db_subnet_group" {

--- a/humanitec-resource-defs/mysql/basic/README.md
+++ b/humanitec-resource-defs/mysql/basic/README.md
@@ -24,10 +24,8 @@
 |------|-------------|------|---------|:--------:|
 | access\_key | n/a | `string` | n/a | yes |
 | database\_name | n/a | `string` | n/a | yes |
-| db\_subnet\_group\_name | n/a | `string` | n/a | yes |
-| name | n/a | `string` | n/a | yes |
 | password | n/a | `string` | n/a | yes |
-| prefix | n/a | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
 | region | n/a | `string` | n/a | yes |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
@@ -40,6 +38,7 @@
 | create\_cloudwatch\_log\_group | n/a | `bool` | `false` | no |
 | create\_db\_subnet\_group | n/a | `bool` | `true` | no |
 | create\_monitoring\_role | n/a | `bool` | `true` | no |
+| db\_subnet\_group\_name | DB subnet group name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | deletion\_protection | n/a | `bool` | `false` | no |
 | enabled\_cloudwatch\_logs\_exports | n/a | `set(string)` | `[]` | no |
 | engine | n/a | `string` | `"mysql"` | no |
@@ -54,6 +53,7 @@
 | monitoring\_role\_name | n/a | `string` | `"rds-basic-monitoring-role"` | no |
 | monitoring\_role\_use\_name\_prefix | n/a | `bool` | `true` | no |
 | multi\_az | n/a | `bool` | `true` | no |
+| name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | parameters | n/a | `set(any)` | `[]` | no |
 | performance\_insights\_enabled | n/a | `bool` | `true` | no |
 | performance\_insights\_retention\_period | n/a | `number` | `7` | no |

--- a/humanitec-resource-defs/mysql/basic/main.tf
+++ b/humanitec-resource-defs/mysql/basic/main.tf
@@ -19,10 +19,12 @@ resource "humanitec_resource_definition" "main" {
         url  = var.resource_packs_aws_url
       }
       variables = {
-        region                                = var.region
-        res_id                                = "$${context.res.id}"
-        app_id                                = "$${context.app.id}"
-        env_id                                = "$${context.env.id}"
+        region = var.region
+        res_id = "$${context.res.id}"
+        app_id = "$${context.app.id}"
+        env_id = "$${context.env.id}"
+
+        prefix                                = var.prefix
         name                                  = var.name
         database_name                         = var.database_name
         username                              = var.username

--- a/humanitec-resource-defs/mysql/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/mysql/basic/terraform.tfvars.example
@@ -1,34 +1,43 @@
-access_key                            = ""
-allocated_storage                     = 20
-backup_retention_period               = 1
-backup_window                         = ""
-create_cloudwatch_log_group           = false
-create_db_subnet_group                = true
-create_monitoring_role                = true
-database_name                         = ""
-db_subnet_group_name                  = ""
-deletion_protection                   = false
-enabled_cloudwatch_logs_exports       = []
-engine                                = "mysql"
-engine_version                        = "8.0"
-group_family                          = "mysql8.0"
-instance_class                        = "db.t4g.large"
-maintenance_window                    = ""
-major_engine_version                  = "8.0"
-max_allocated_storage                 = 100
-monitoring_interval                   = 60
-monitoring_role_description           = "Monitoring role for RDS basic cluster"
-monitoring_role_name                  = "rds-basic-monitoring-role"
-monitoring_role_use_name_prefix       = true
-multi_az                              = true
-name                                  = ""
+access_key                  = ""
+allocated_storage           = 20
+backup_retention_period     = 1
+backup_window               = ""
+create_cloudwatch_log_group = false
+create_db_subnet_group      = true
+create_monitoring_role      = true
+database_name               = ""
+
+# DB subnet group name (can contain placeholders like ${context.app.id})
+db_subnet_group_name = ""
+
+deletion_protection             = false
+enabled_cloudwatch_logs_exports = []
+engine                          = "mysql"
+engine_version                  = "8.0"
+group_family                    = "mysql8.0"
+instance_class                  = "db.t4g.large"
+maintenance_window              = ""
+major_engine_version            = "8.0"
+max_allocated_storage           = 100
+monitoring_interval             = 60
+monitoring_role_description     = "Monitoring role for RDS basic cluster"
+monitoring_role_name            = "rds-basic-monitoring-role"
+monitoring_role_use_name_prefix = true
+multi_az                        = true
+
+# Resource name (can contain placeholders like ${context.app.id})
+name = ""
+
 parameters                            = []
 password                              = ""
 performance_insights_enabled          = true
 performance_insights_retention_period = 7
 port                                  = 3306
-prefix                                = ""
-region                                = ""
+
+# Prefix for all resources
+prefix = ""
+
+region = ""
 
 # AWS Resource Pack git branch
 resource_packs_aws_rev = ""

--- a/humanitec-resource-defs/mysql/basic/variables.tf
+++ b/humanitec-resource-defs/mysql/basic/variables.tf
@@ -1,5 +1,6 @@
 variable "prefix" {
-  type = string
+  description = "Prefix for all resources"
+  type        = string
 }
 
 variable "resource_packs_aws_url" {
@@ -26,7 +27,9 @@ variable "secret_key" {
 }
 
 variable "name" {
-  type = string
+  type        = string
+  description = "Resource name (can contain placeholders like $${context.app.id})"
+  default     = ""
 }
 
 variable "database_name" {
@@ -49,7 +52,9 @@ variable "create_db_subnet_group" {
 }
 
 variable "db_subnet_group_name" {
-  type = string
+  type        = string
+  description = "DB subnet group name (can contain placeholders like $${context.app.id})"
+  default     = ""
 }
 
 variable "subnet_ids" {

--- a/humanitec-resource-defs/postgres/aurora/README.md
+++ b/humanitec-resource-defs/postgres/aurora/README.md
@@ -24,11 +24,9 @@
 |------|-------------|------|---------|:--------:|
 | access\_key | n/a | `string` | n/a | yes |
 | database\_name | n/a | `string` | n/a | yes |
-| db\_subnet\_group\_name | n/a | `string` | n/a | yes |
 | master\_password | n/a | `string` | n/a | yes |
 | master\_username | n/a | `string` | n/a | yes |
-| name | n/a | `string` | n/a | yes |
-| prefix | n/a | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
 | region | n/a | `string` | n/a | yes |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
@@ -42,12 +40,14 @@
 | db\_cluster\_activity\_stream\_mode | n/a | `string` | `"async"` | no |
 | db\_cluster\_parameter\_group\_parameters | n/a | `set(any)` | `[]` | no |
 | db\_parameter\_group\_parameters | n/a | `set(any)` | `[]` | no |
+| db\_subnet\_group\_name | DB subnet group name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | enabled\_cloudwatch\_logs\_exports | n/a | `set(string)` | `[]` | no |
 | endpoints | n/a | `any` | `{}` | no |
 | engine | n/a | `string` | `"aurora-postgresql"` | no |
 | engine\_version | n/a | `string` | `"14.7"` | no |
 | group\_family | n/a | `string` | `"aurora-postgresql14"` | no |
 | instances | n/a | `map(any)` | <pre>{<br>  "1": {<br>    "db_parameter_group_name": "default.aurora-postgresql14",<br>    "instance_class": "db.r5.2xlarge",<br>    "publicly_accessible": true<br>  },<br>  "2": {<br>    "identifier": "static-member-1",<br>    "instance_class": "db.r5.2xlarge"<br>  }<br>}</pre> | no |
+| name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 | security\_group\_rules | n/a | `any` | `{}` | no |
 | skip\_final\_snapshot | n/a | `bool` | `true` | no |

--- a/humanitec-resource-defs/postgres/aurora/main.tf
+++ b/humanitec-resource-defs/postgres/aurora/main.tf
@@ -25,6 +25,7 @@ resource "humanitec_resource_definition" "main" {
         app_id = "$${context.app.id}"
         env_id = "$${context.env.id}"
 
+        prefix                                = var.prefix
         name                                  = var.name
         database_name                         = var.database_name
         master_username                       = var.master_username

--- a/humanitec-resource-defs/postgres/aurora/terraform.tfvars.example
+++ b/humanitec-resource-defs/postgres/aurora/terraform.tfvars.example
@@ -8,12 +8,15 @@ db_cluster_activity_stream_kms_key_id = ""
 db_cluster_activity_stream_mode       = "async"
 db_cluster_parameter_group_parameters = []
 db_parameter_group_parameters         = []
-db_subnet_group_name                  = ""
-enabled_cloudwatch_logs_exports       = []
-endpoints                             = {}
-engine                                = "aurora-postgresql"
-engine_version                        = "14.7"
-group_family                          = "aurora-postgresql14"
+
+# DB subnet group name (can contain placeholders like ${context.app.id})
+db_subnet_group_name = ""
+
+enabled_cloudwatch_logs_exports = []
+endpoints                       = {}
+engine                          = "aurora-postgresql"
+engine_version                  = "14.7"
+group_family                    = "aurora-postgresql14"
 instances = {
   "1": {
     "db_parameter_group_name": "default.aurora-postgresql14",
@@ -27,9 +30,14 @@ instances = {
 }
 master_password = ""
 master_username = ""
-name            = ""
-prefix          = ""
-region          = ""
+
+# Resource name (can contain placeholders like ${context.app.id})
+name = ""
+
+# Prefix for all resources
+prefix = ""
+
+region = ""
 
 # AWS Resource Pack git branch
 resource_packs_aws_rev = ""

--- a/humanitec-resource-defs/postgres/aurora/variables.tf
+++ b/humanitec-resource-defs/postgres/aurora/variables.tf
@@ -1,5 +1,6 @@
 variable "prefix" {
-  type = string
+  description = "Prefix for all resources"
+  type        = string
 }
 
 variable "resource_packs_aws_url" {
@@ -26,7 +27,9 @@ variable "region" {
 }
 
 variable "name" {
-  type = string
+  type        = string
+  description = "Resource name (can contain placeholders like $${context.app.id})"
+  default     = ""
 }
 
 variable "database_name" {
@@ -50,7 +53,9 @@ variable "subnets" {
 }
 
 variable "db_subnet_group_name" {
-  type = string
+  type        = string
+  description = "DB subnet group name (can contain placeholders like $${context.app.id})"
+  default     = ""
 }
 
 variable "create_db_subnet_group" {

--- a/humanitec-resource-defs/postgres/basic/README.md
+++ b/humanitec-resource-defs/postgres/basic/README.md
@@ -24,10 +24,8 @@
 |------|-------------|------|---------|:--------:|
 | access\_key | n/a | `string` | n/a | yes |
 | database\_name | n/a | `string` | n/a | yes |
-| db\_subnet\_group\_name | n/a | `string` | n/a | yes |
-| name | n/a | `string` | n/a | yes |
 | password | n/a | `string` | n/a | yes |
-| prefix | n/a | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
 | region | n/a | `string` | n/a | yes |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
@@ -40,6 +38,7 @@
 | create\_cloudwatch\_log\_group | n/a | `bool` | `false` | no |
 | create\_db\_subnet\_group | n/a | `bool` | `true` | no |
 | create\_monitoring\_role | n/a | `bool` | `true` | no |
+| db\_subnet\_group\_name | DB subnet group name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | deletion\_protection | n/a | `bool` | `false` | no |
 | enabled\_cloudwatch\_logs\_exports | n/a | `set(string)` | `[]` | no |
 | engine | n/a | `string` | `"postgres"` | no |
@@ -54,6 +53,7 @@
 | monitoring\_role\_name | n/a | `string` | `"rds-basic-monitoring-role"` | no |
 | monitoring\_role\_use\_name\_prefix | n/a | `bool` | `true` | no |
 | multi\_az | n/a | `bool` | `true` | no |
+| name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | parameters | n/a | `set(any)` | `[]` | no |
 | performance\_insights\_enabled | n/a | `bool` | `true` | no |
 | performance\_insights\_retention\_period | n/a | `number` | `7` | no |

--- a/humanitec-resource-defs/postgres/basic/main.tf
+++ b/humanitec-resource-defs/postgres/basic/main.tf
@@ -19,10 +19,12 @@ resource "humanitec_resource_definition" "main" {
         url  = var.resource_packs_aws_url
       }
       variables = {
-        region                                = var.region
-        res_id                                = "$${context.res.id}"
-        app_id                                = "$${context.app.id}"
-        env_id                                = "$${context.env.id}"
+        region = var.region
+        res_id = "$${context.res.id}"
+        app_id = "$${context.app.id}"
+        env_id = "$${context.env.id}"
+
+        prefix                                = var.prefix
         name                                  = var.name
         database_name                         = var.database_name
         username                              = var.username

--- a/humanitec-resource-defs/postgres/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/postgres/basic/terraform.tfvars.example
@@ -1,34 +1,43 @@
-access_key                            = ""
-allocated_storage                     = 20
-backup_retention_period               = 1
-backup_window                         = ""
-create_cloudwatch_log_group           = false
-create_db_subnet_group                = true
-create_monitoring_role                = true
-database_name                         = ""
-db_subnet_group_name                  = ""
-deletion_protection                   = false
-enabled_cloudwatch_logs_exports       = []
-engine                                = "postgres"
-engine_version                        = "14"
-group_family                          = "postgres14"
-instance_class                        = "db.t4g.large"
-maintenance_window                    = ""
-major_engine_version                  = "14"
-max_allocated_storage                 = 100
-monitoring_interval                   = 60
-monitoring_role_description           = "Monitoring role for RDS basic cluster"
-monitoring_role_name                  = "rds-basic-monitoring-role"
-monitoring_role_use_name_prefix       = true
-multi_az                              = true
-name                                  = ""
+access_key                  = ""
+allocated_storage           = 20
+backup_retention_period     = 1
+backup_window               = ""
+create_cloudwatch_log_group = false
+create_db_subnet_group      = true
+create_monitoring_role      = true
+database_name               = ""
+
+# DB subnet group name (can contain placeholders like ${context.app.id})
+db_subnet_group_name = ""
+
+deletion_protection             = false
+enabled_cloudwatch_logs_exports = []
+engine                          = "postgres"
+engine_version                  = "14"
+group_family                    = "postgres14"
+instance_class                  = "db.t4g.large"
+maintenance_window              = ""
+major_engine_version            = "14"
+max_allocated_storage           = 100
+monitoring_interval             = 60
+monitoring_role_description     = "Monitoring role for RDS basic cluster"
+monitoring_role_name            = "rds-basic-monitoring-role"
+monitoring_role_use_name_prefix = true
+multi_az                        = true
+
+# Resource name (can contain placeholders like ${context.app.id})
+name = ""
+
 parameters                            = []
 password                              = ""
 performance_insights_enabled          = true
 performance_insights_retention_period = 7
 port                                  = 5432
-prefix                                = ""
-region                                = ""
+
+# Prefix for all resources
+prefix = ""
+
+region = ""
 
 # AWS Resource Pack git branch
 resource_packs_aws_rev = ""

--- a/humanitec-resource-defs/postgres/basic/variables.tf
+++ b/humanitec-resource-defs/postgres/basic/variables.tf
@@ -1,5 +1,6 @@
 variable "prefix" {
-  type = string
+  description = "Prefix for all resources"
+  type        = string
 }
 
 variable "resource_packs_aws_url" {
@@ -26,7 +27,9 @@ variable "secret_key" {
 }
 
 variable "name" {
-  type = string
+  type        = string
+  description = "Resource name (can contain placeholders like $${context.app.id})"
+  default     = ""
 }
 
 variable "database_name" {
@@ -49,7 +52,9 @@ variable "create_db_subnet_group" {
 }
 
 variable "db_subnet_group_name" {
-  type = string
+  type        = string
+  description = "DB subnet group name (can contain placeholders like $${context.app.id})"
+  default     = ""
 }
 
 variable "subnet_ids" {

--- a/humanitec-resource-defs/redis/basic/README.md
+++ b/humanitec-resource-defs/redis/basic/README.md
@@ -29,6 +29,7 @@
 | secret\_key | AWS Secret Key | `string` | n/a | yes |
 | security\_group\_ids | List of AWS security group IDs to use for the AWS ElastiCache cluster | `set(string)` | n/a | yes |
 | subnet\_group\_name | Name of the AWS ElastiCache subnet group to use | `string` | n/a | yes |
+| name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | node\_type | AWS ElastiCache node type | `string` | `"cache.t4g.micro"` | no |
 | num\_cache\_clusters | Number of AWS ElastiCache clusters | `number` | `1` | no |
 | parameter\_group\_name | AWS ElastiCache parameter group name | `string` | `"default.redis7.cluster.on"` | no |

--- a/humanitec-resource-defs/redis/basic/main.tf
+++ b/humanitec-resource-defs/redis/basic/main.tf
@@ -20,8 +20,9 @@ resource "humanitec_resource_definition" "main" {
       }
 
       variables = {
-        region = var.region,
-        prefix = "${var.prefix}redis-basic"
+        region = var.region
+        prefix = var.prefix
+        name   = var.name
 
         res_id = "$${context.res.id}"
         app_id = "$${context.app.id}"

--- a/humanitec-resource-defs/redis/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/redis/basic/terraform.tfvars.example
@@ -2,6 +2,9 @@
 # AWS Access Key
 access_key = ""
 
+# Resource name (can contain placeholders like ${context.app.id})
+name = ""
+
 # AWS ElastiCache node type
 node_type = "cache.t4g.micro"
 

--- a/humanitec-resource-defs/redis/basic/variables.tf
+++ b/humanitec-resource-defs/redis/basic/variables.tf
@@ -56,3 +56,9 @@ variable "security_group_ids" {
   description = "List of AWS security group IDs to use for the AWS ElastiCache cluster"
   type        = set(string)
 }
+
+variable "name" {
+  type        = string
+  description = "Resource name (can contain placeholders like $${context.app.id})"
+  default     = ""
+}

--- a/humanitec-resource-defs/s3/basic/README.md
+++ b/humanitec-resource-defs/s3/basic/README.md
@@ -23,10 +23,11 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | access\_key | n/a | `string` | n/a | yes |
-| prefix | n/a | `string` | n/a | yes |
+| prefix | Name prefix | `string` | n/a | yes |
 | region | n/a | `string` | n/a | yes |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
+| name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 
 ## Outputs

--- a/humanitec-resource-defs/s3/basic/main.tf
+++ b/humanitec-resource-defs/s3/basic/main.tf
@@ -20,11 +20,9 @@ resource "humanitec_resource_definition" "main" {
       }
 
       variables = {
-        region = var.region,
-        # TODO: How to template the bucket name?
-        # Name restrictions https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-        # prefix = "${var.prefix}$${context.res.id}"
-        prefix = "${var.prefix}basic-bucket"
+        region = var.region
+        prefix = var.prefix
+        name   = var.name
 
         res_id = "$${context.res.id}"
         app_id = "$${context.app.id}"

--- a/humanitec-resource-defs/s3/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/s3/basic/terraform.tfvars.example
@@ -1,6 +1,12 @@
 access_key = ""
-prefix     = ""
-region     = ""
+
+# Resource name (can contain placeholders like ${context.app.id})
+name = ""
+
+# Name prefix
+prefix = ""
+
+region = ""
 
 # AWS Resource Pack git branch
 resource_packs_aws_rev = ""

--- a/humanitec-resource-defs/s3/basic/variables.tf
+++ b/humanitec-resource-defs/s3/basic/variables.tf
@@ -1,7 +1,3 @@
-variable "prefix" {
-  type = string
-}
-
 variable "resource_packs_aws_url" {
   description = "AWS Resource Pack git url"
   type        = string
@@ -23,4 +19,15 @@ variable "secret_key" {
 
 variable "region" {
   type = string
+}
+
+variable "prefix" {
+  type        = string
+  description = "Name prefix"
+}
+
+variable "name" {
+  type        = string
+  description = "Resource name (can contain placeholders like $${context.app.id})"
+  default     = ""
 }

--- a/humanitec-resource-defs/sqs/basic/README.md
+++ b/humanitec-resource-defs/sqs/basic/README.md
@@ -23,10 +23,11 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | access\_key | n/a | `string` | n/a | yes |
-| prefix | n/a | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
 | region | n/a | `string` | n/a | yes |
 | resource\_packs\_aws\_rev | AWS Resource Pack git branch | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
+| name | Resource name (can contain placeholders like ${context.app.id}) | `string` | `""` | no |
 | resource\_packs\_aws\_url | AWS Resource Pack git url | `string` | `"https://github.com/humanitec-architecture/resource-packs-aws.git"` | no |
 
 ## Outputs

--- a/humanitec-resource-defs/sqs/basic/main.tf
+++ b/humanitec-resource-defs/sqs/basic/main.tf
@@ -20,11 +20,9 @@ resource "humanitec_resource_definition" "main" {
       }
 
       variables = {
-        region = var.region,
-        # TODO: How to template the queue name?
-        # Name restrictions https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-queues.html
-        # prefix = "${var.prefix}$${context.res.id}"
-        prefix = "${var.prefix}basic-queue"
+        region = var.region
+        prefix = var.prefix
+        name   = var.name
 
         res_id = "$${context.res.id}"
         app_id = "$${context.app.id}"

--- a/humanitec-resource-defs/sqs/basic/terraform.tfvars.example
+++ b/humanitec-resource-defs/sqs/basic/terraform.tfvars.example
@@ -1,6 +1,12 @@
 access_key = ""
-prefix     = ""
-region     = ""
+
+# Resource name (can contain placeholders like ${context.app.id})
+name = ""
+
+# Prefix for all resources
+prefix = ""
+
+region = ""
 
 # AWS Resource Pack git branch
 resource_packs_aws_rev = ""

--- a/humanitec-resource-defs/sqs/basic/variables.tf
+++ b/humanitec-resource-defs/sqs/basic/variables.tf
@@ -1,7 +1,7 @@
 variable "prefix" {
-  type = string
+  description = "Prefix for all resources"
+  type        = string
 }
-
 variable "resource_packs_aws_url" {
   description = "AWS Resource Pack git url"
   type        = string
@@ -23,4 +23,10 @@ variable "secret_key" {
 
 variable "region" {
   type = string
+}
+
+variable "name" {
+  type        = string
+  description = "Resource name (can contain placeholders like $${context.app.id})"
+  default     = ""
 }

--- a/modules/iam-role/service-account/README.md
+++ b/modules/iam-role/service-account/README.md
@@ -31,10 +31,11 @@
 | env\_id | n/a | `string` | n/a | yes |
 | namespace | n/a | `string` | n/a | yes |
 | policy\_arns | n/a | `set(string)` | n/a | yes |
-| prefix | n/a | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
 | region | n/a | `string` | n/a | yes |
 | res\_id | n/a | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
+| name | Resource name | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/iam-role/service-account/terraform.tfvars.example
+++ b/modules/iam-role/service-account/terraform.tfvars.example
@@ -2,9 +2,16 @@ access_key   = ""
 app_id       = ""
 cluster_name = ""
 env_id       = ""
-namespace    = ""
-policy_arns  = ""
-prefix       = ""
-region       = ""
-res_id       = ""
-secret_key   = ""
+
+# Resource name
+name = ""
+
+namespace   = ""
+policy_arns = ""
+
+# Prefix for all resources
+prefix = ""
+
+region     = ""
+res_id     = ""
+secret_key = ""

--- a/modules/iam-role/service-account/variables.tf
+++ b/modules/iam-role/service-account/variables.tf
@@ -1,5 +1,6 @@
 variable "prefix" {
-  type = string
+  type        = string
+  description = "Prefix for all resources"
 }
 
 variable "region" {
@@ -36,4 +37,10 @@ variable "env_id" {
 
 variable "res_id" {
   type = string
+}
+
+variable "name" {
+  type        = string
+  description = "Resource name"
+  default     = ""
 }

--- a/modules/rds/aurora/README.md
+++ b/modules/rds/aurora/README.md
@@ -20,11 +20,10 @@
 | access\_key | n/a | `string` | n/a | yes |
 | app\_id | n/a | `string` | n/a | yes |
 | database\_name | n/a | `string` | n/a | yes |
-| db\_subnet\_group\_name | n/a | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
 | master\_password | n/a | `string` | n/a | yes |
 | master\_username | n/a | `string` | n/a | yes |
-| name | n/a | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
 | region | n/a | `string` | n/a | yes |
 | res\_id | n/a | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
@@ -38,12 +37,14 @@
 | db\_cluster\_activity\_stream\_mode | n/a | `string` | `"async"` | no |
 | db\_cluster\_parameter\_group\_parameters | n/a | `set(any)` | `[]` | no |
 | db\_parameter\_group\_parameters | n/a | `set(any)` | `[]` | no |
+| db\_subnet\_group\_name | DB subnet group name | `string` | `""` | no |
 | enabled\_cloudwatch\_logs\_exports | n/a | `set(string)` | `[]` | no |
 | endpoints | n/a | `any` | `{}` | no |
 | engine | n/a | `string` | `"aurora-postgresql"` | no |
 | engine\_version | n/a | `string` | `"14.7"` | no |
 | group\_family | n/a | `string` | `"aurora-postgresql14"` | no |
 | instances | n/a | `map(any)` | <pre>{<br>  "1": {<br>    "db_parameter_group_name": "default.aurora-postgresql14",<br>    "instance_class": "db.r5.2xlarge",<br>    "publicly_accessible": true<br>  },<br>  "2": {<br>    "identifier": "static-member-1",<br>    "instance_class": "db.r5.2xlarge"<br>  }<br>}</pre> | no |
+| name | Resource name | `string` | `""` | no |
 | security\_group\_rules | n/a | `any` | `{}` | no |
 | skip\_final\_snapshot | n/a | `bool` | `true` | no |
 | storage\_encrypted | n/a | `bool` | `true` | no |

--- a/modules/rds/aurora/main.tf
+++ b/modules/rds/aurora/main.tf
@@ -1,8 +1,13 @@
+locals {
+  # Name restrictions https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/CHAP_Limits.html#RDS_Limits.Constraints
+  default_name = trimsuffix(substr("${var.prefix}${var.app_id}-${var.env_id}-${replace(var.res_id, ".", "-")}", 0, 63), "-")
+}
+
 module "aurora" {
   source  = "terraform-aws-modules/rds-aurora/aws"
   version = "9.0.0"
 
-  name          = var.name
+  name          = coalesce(var.name, local.default_name)
   database_name = var.database_name
 
   engine         = var.engine
@@ -23,7 +28,7 @@ module "aurora" {
   subnets = var.subnets
 
   create_db_subnet_group = var.create_db_subnet_group
-  db_subnet_group_name   = var.db_subnet_group_name
+  db_subnet_group_name   = coalesce(var.db_subnet_group_name, local.default_name)
   security_group_rules   = var.security_group_rules
 
   apply_immediately   = var.apply_immediately

--- a/modules/rds/aurora/terraform.tfvars.example
+++ b/modules/rds/aurora/terraform.tfvars.example
@@ -9,13 +9,16 @@ db_cluster_activity_stream_kms_key_id = ""
 db_cluster_activity_stream_mode       = "async"
 db_cluster_parameter_group_parameters = []
 db_parameter_group_parameters         = []
-db_subnet_group_name                  = ""
-enabled_cloudwatch_logs_exports       = []
-endpoints                             = {}
-engine                                = "aurora-postgresql"
-engine_version                        = "14.7"
-env_id                                = ""
-group_family                          = "aurora-postgresql14"
+
+# DB subnet group name
+db_subnet_group_name = ""
+
+enabled_cloudwatch_logs_exports = []
+endpoints                       = {}
+engine                          = "aurora-postgresql"
+engine_version                  = "14.7"
+env_id                          = ""
+group_family                    = "aurora-postgresql14"
 instances = {
   "1": {
     "db_parameter_group_name": "default.aurora-postgresql14",
@@ -27,9 +30,15 @@ instances = {
     "instance_class": "db.r5.2xlarge"
   }
 }
-master_password      = ""
-master_username      = ""
-name                 = ""
+master_password = ""
+master_username = ""
+
+# Resource name
+name = ""
+
+# Prefix for all resources
+prefix = ""
+
 region               = ""
 res_id               = ""
 secret_key           = ""

--- a/modules/rds/aurora/variables.tf
+++ b/modules/rds/aurora/variables.tf
@@ -1,3 +1,8 @@
+variable "prefix" {
+  type        = string
+  description = "Prefix for all resources"
+}
+
 variable "region" {
   type = string
 }
@@ -23,7 +28,9 @@ variable "res_id" {
 }
 
 variable "name" {
-  type = string
+  type        = string
+  description = "Resource name"
+  default     = ""
 }
 
 variable "database_name" {
@@ -47,7 +54,9 @@ variable "subnets" {
 }
 
 variable "db_subnet_group_name" {
-  type = string
+  type        = string
+  description = "DB subnet group name"
+  default     = ""
 }
 
 variable "create_db_subnet_group" {

--- a/modules/rds/basic/README.md
+++ b/modules/rds/basic/README.md
@@ -19,10 +19,9 @@
 | access\_key | n/a | `string` | n/a | yes |
 | app\_id | n/a | `string` | n/a | yes |
 | database\_name | n/a | `string` | n/a | yes |
-| db\_subnet\_group\_name | n/a | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
-| name | n/a | `string` | n/a | yes |
 | password | n/a | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
 | region | n/a | `string` | n/a | yes |
 | res\_id | n/a | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
@@ -35,6 +34,7 @@
 | create\_cloudwatch\_log\_group | n/a | `bool` | `false` | no |
 | create\_db\_subnet\_group | n/a | `bool` | `true` | no |
 | create\_monitoring\_role | n/a | `bool` | `true` | no |
+| db\_subnet\_group\_name | DB subnet group name | `string` | `""` | no |
 | deletion\_protection | n/a | `bool` | `false` | no |
 | enabled\_cloudwatch\_logs\_exports | n/a | `set(string)` | `[]` | no |
 | engine | n/a | `string` | `"postgres"` | no |
@@ -49,6 +49,7 @@
 | monitoring\_role\_name | n/a | `string` | `"rds-monitoring-role"` | no |
 | monitoring\_role\_use\_name\_prefix | n/a | `bool` | `true` | no |
 | multi\_az | n/a | `bool` | `true` | no |
+| name | Resource name | `string` | `""` | no |
 | parameters | n/a | `set(any)` | `[]` | no |
 | performance\_insights\_enabled | n/a | `bool` | `true` | no |
 | performance\_insights\_retention\_period | n/a | `number` | `7` | no |

--- a/modules/rds/basic/main.tf
+++ b/modules/rds/basic/main.tf
@@ -1,8 +1,13 @@
+locals {
+  # Name restrictions https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints
+  default_name = trimsuffix(substr("${var.prefix}${var.app_id}-${var.env_id}-${replace(var.res_id, ".", "-")}", 0, 63), "-")
+}
+
 module "db" {
   source  = "terraform-aws-modules/rds/aws"
   version = "6.3.0"
 
-  identifier = var.name
+  identifier = coalesce(var.name, local.default_name)
   db_name    = var.database_name
   port       = var.port
 
@@ -22,7 +27,7 @@ module "db" {
   multi_az = var.multi_az
 
   create_db_subnet_group = var.create_db_subnet_group
-  db_subnet_group_name   = var.db_subnet_group_name
+  db_subnet_group_name   = coalesce(var.db_subnet_group_name, local.default_name)
   subnet_ids             = var.subnet_ids
 
   vpc_security_group_ids = var.vpc_security_group_ids

--- a/modules/rds/basic/terraform.tfvars.example
+++ b/modules/rds/basic/terraform.tfvars.example
@@ -1,38 +1,48 @@
-access_key                            = ""
-allocated_storage                     = 20
-app_id                                = ""
-backup_retention_period               = 1
-backup_window                         = ""
-create_cloudwatch_log_group           = false
-create_db_subnet_group                = true
-create_monitoring_role                = true
-database_name                         = ""
-db_subnet_group_name                  = ""
-deletion_protection                   = false
-enabled_cloudwatch_logs_exports       = []
-engine                                = "postgres"
-engine_version                        = "14"
-env_id                                = ""
-group_family                          = "postgres14"
-instance_class                        = "db.t4g.large"
-maintenance_window                    = ""
-major_engine_version                  = "14"
-max_allocated_storage                 = 100
-monitoring_interval                   = 60
-monitoring_role_description           = "Monitoring role for RDS cluster"
-monitoring_role_name                  = "rds-monitoring-role"
-monitoring_role_use_name_prefix       = true
-multi_az                              = true
-name                                  = ""
+access_key                  = ""
+allocated_storage           = 20
+app_id                      = ""
+backup_retention_period     = 1
+backup_window               = ""
+create_cloudwatch_log_group = false
+create_db_subnet_group      = true
+create_monitoring_role      = true
+database_name               = ""
+
+# DB subnet group name
+db_subnet_group_name = ""
+
+deletion_protection             = false
+enabled_cloudwatch_logs_exports = []
+engine                          = "postgres"
+engine_version                  = "14"
+env_id                          = ""
+group_family                    = "postgres14"
+instance_class                  = "db.t4g.large"
+maintenance_window              = ""
+major_engine_version            = "14"
+max_allocated_storage           = 100
+monitoring_interval             = 60
+monitoring_role_description     = "Monitoring role for RDS cluster"
+monitoring_role_name            = "rds-monitoring-role"
+monitoring_role_use_name_prefix = true
+multi_az                        = true
+
+# Resource name
+name = ""
+
 parameters                            = []
 password                              = ""
 performance_insights_enabled          = true
 performance_insights_retention_period = 7
 port                                  = 5432
-region                                = ""
-res_id                                = ""
-secret_key                            = ""
-skip_final_snapshot                   = true
-subnet_ids                            = ""
-username                              = ""
-vpc_security_group_ids                = ""
+
+# Prefix for all resources
+prefix = ""
+
+region                 = ""
+res_id                 = ""
+secret_key             = ""
+skip_final_snapshot    = true
+subnet_ids             = ""
+username               = ""
+vpc_security_group_ids = ""

--- a/modules/rds/basic/variables.tf
+++ b/modules/rds/basic/variables.tf
@@ -1,3 +1,8 @@
+variable "prefix" {
+  type        = string
+  description = "Prefix for all resources"
+}
+
 variable "region" {
   type = string
 }
@@ -23,7 +28,9 @@ variable "res_id" {
 }
 
 variable "name" {
-  type = string
+  type        = string
+  description = "Resource name"
+  default     = ""
 }
 
 variable "database_name" {
@@ -46,7 +53,9 @@ variable "create_db_subnet_group" {
 }
 
 variable "db_subnet_group_name" {
-  type = string
+  type        = string
+  description = "DB subnet group name"
+  default     = ""
 }
 
 variable "subnet_ids" {

--- a/modules/redis/basic/README.md
+++ b/modules/redis/basic/README.md
@@ -34,6 +34,7 @@
 | secret\_key | AWS Secret Key | `string` | n/a | yes |
 | security\_group\_ids | List of AWS security group IDs to use for the AWS ElastiCache cluster | `set(string)` | n/a | yes |
 | subnet\_group\_name | Name of the AWS ElastiCache subnet group to use | `string` | n/a | yes |
+| name | Resource name | `string` | `""` | no |
 | node\_type | AWS ElastiCache node type | `string` | `"cache.t4g.micro"` | no |
 | num\_cache\_clusters | Number of AWS ElastiCache clusters | `number` | `1` | no |
 | parameter\_group\_name | AWS ElastiCache parameter group name | `string` | `"default.redis7.cluster.on"` | no |

--- a/modules/redis/basic/main.tf
+++ b/modules/redis/basic/main.tf
@@ -1,3 +1,8 @@
+locals {
+  # Name restrictions https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheCluster.html
+  default_name = trimsuffix(substr("${var.prefix}${var.app_id}-${var.env_id}-${replace(var.res_id, ".", "-")}", 0, 50), "-")
+}
+
 resource "random_password" "auth_token" {
   length  = 16
   special = false
@@ -5,8 +10,8 @@ resource "random_password" "auth_token" {
 
 resource "aws_elasticache_replication_group" "main" {
   automatic_failover_enabled = true
-  replication_group_id       = var.prefix
-  description                = var.prefix
+  replication_group_id       = coalesce(var.name, local.default_name)
+  description                = coalesce(var.name, local.default_name)
   node_type                  = var.node_type
   num_cache_clusters         = var.num_cache_clusters
   parameter_group_name       = var.parameter_group_name # tflint-ignore: aws_elasticache_replication_group_default_parameter_group

--- a/modules/redis/basic/terraform.tfvars.example
+++ b/modules/redis/basic/terraform.tfvars.example
@@ -5,6 +5,9 @@ access_key = ""
 app_id = ""
 env_id = ""
 
+# Resource name
+name = ""
+
 # AWS ElastiCache node type
 node_type = "cache.t4g.micro"
 

--- a/modules/redis/basic/variables.tf
+++ b/modules/redis/basic/variables.tf
@@ -30,6 +30,12 @@ variable "res_id" {
   type = string
 }
 
+variable "name" {
+  type        = string
+  description = "Resource name"
+  default     = ""
+}
+
 variable "node_type" {
   description = "AWS ElastiCache node type"
   type        = string

--- a/modules/s3/basic/README.md
+++ b/modules/s3/basic/README.md
@@ -27,11 +27,12 @@
 | access\_key | n/a | `string` | n/a | yes |
 | app\_id | n/a | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
-| prefix | n/a | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
 | region | n/a | `string` | n/a | yes |
 | res\_id | n/a | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
 | force\_destroy | n/a | `bool` | `true` | no |
+| name | Resource name | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/s3/basic/main.tf
+++ b/modules/s3/basic/main.tf
@@ -1,5 +1,10 @@
+locals {
+  # Name restrictions https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+  default_name = trimsuffix(substr("${var.prefix}${var.app_id}-${var.env_id}-${replace(var.res_id, ".", "-")}", 0, 63), "-")
+}
+
 resource "aws_s3_bucket" "main" {
-  bucket_prefix = var.prefix
+  bucket        = coalesce(var.name, local.default_name)
   force_destroy = var.force_destroy
 }
 

--- a/modules/s3/basic/terraform.tfvars.example
+++ b/modules/s3/basic/terraform.tfvars.example
@@ -2,7 +2,13 @@ access_key    = ""
 app_id        = ""
 env_id        = ""
 force_destroy = true
-prefix        = ""
-region        = ""
-res_id        = ""
-secret_key    = ""
+
+# Resource name
+name = ""
+
+# Prefix for all resources
+prefix = ""
+
+region     = ""
+res_id     = ""
+secret_key = ""

--- a/modules/s3/basic/variables.tf
+++ b/modules/s3/basic/variables.tf
@@ -1,5 +1,6 @@
 variable "prefix" {
-  type = string
+  type        = string
+  description = "Prefix for all resources"
 }
 
 variable "region" {
@@ -17,6 +18,12 @@ variable "secret_key" {
 variable "force_destroy" {
   type    = bool
   default = true
+}
+
+variable "name" {
+  type        = string
+  description = "Resource name"
+  default     = ""
 }
 
 variable "app_id" {

--- a/modules/sqs/basic/README.md
+++ b/modules/sqs/basic/README.md
@@ -19,10 +19,11 @@
 | access\_key | n/a | `string` | n/a | yes |
 | app\_id | n/a | `string` | n/a | yes |
 | env\_id | n/a | `string` | n/a | yes |
-| prefix | n/a | `string` | n/a | yes |
+| prefix | Prefix for all resources | `string` | n/a | yes |
 | region | n/a | `string` | n/a | yes |
 | res\_id | n/a | `string` | n/a | yes |
 | secret\_key | n/a | `string` | n/a | yes |
+| name | Resource name | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/sqs/basic/main.tf
+++ b/modules/sqs/basic/main.tf
@@ -1,7 +1,12 @@
+locals {
+  # Name restrictions https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-queues.html
+  default_name = trimsuffix(substr("${var.prefix}${var.app_id}-${var.env_id}-${replace(var.res_id, ".", "-")}", 0, 80), "-")
+}
+
+
 module "sqs" {
   source  = "terraform-aws-modules/sqs/aws"
   version = "~> 4"
 
-  name            = var.prefix
-  use_name_prefix = true
+  name = coalesce(var.name, local.default_name)
 }

--- a/modules/sqs/basic/terraform.tfvars.example
+++ b/modules/sqs/basic/terraform.tfvars.example
@@ -1,7 +1,13 @@
 access_key = ""
 app_id     = ""
 env_id     = ""
-prefix     = ""
+
+# Resource name
+name = ""
+
+# Prefix for all resources
+prefix = ""
+
 region     = ""
 res_id     = ""
 secret_key = ""

--- a/modules/sqs/basic/variables.tf
+++ b/modules/sqs/basic/variables.tf
@@ -1,5 +1,6 @@
 variable "prefix" {
-  type = string
+  type        = string
+  description = "Prefix for all resources"
 }
 
 variable "region" {
@@ -24,4 +25,10 @@ variable "env_id" {
 
 variable "res_id" {
   type = string
+}
+
+variable "name" {
+  type        = string
+  description = "Resource name"
+  default     = ""
 }


### PR DESCRIPTION
Every resource gets an customisable `name` variable, that can be passed from the outside directly (or from a template).

If this isn't provided, we default to `{prefix}-{app-id}-{env-id}-{res-id}`, cleanup all unsupported chars and trim to the expected length.

I would also propose to name the example apps, `hum-rp-example-{resource-type}` to simplify finding them and "test" doesn't sound really encouraging.

The generated s3 resource name in this case is a bit long, but I don't really see a way around this (unless we drop the prefix from the resource name itself 🤔 )

<img width="603" alt="image" src="https://github.com/humanitec-architecture/resource-packs-aws/assets/864578/a823778a-9b0a-40ea-a7d0-ee6ab70886be">

If this looks good I'll update the remaining resources/examples.
